### PR TITLE
ResponseCurve: fix edge to Compound pubchem ID

### DIFF
--- a/bmeg.protograph.yaml
+++ b/bmeg.protograph.yaml
@@ -117,11 +117,12 @@
 
 - label: ResponseCurve
   edges:
-    - fromLabel: Biosample
+    - index: compounds
+      fromLabel: Biosample
       label: responseTo
       toLabel: Compound
       from: "{{sample}}"
-      to: "{{compound}}"
+      to: "{{_index.compound}}"
       merge: true
 
 - label: Compound


### PR DESCRIPTION
Closes #39 

Not ready: I haven't run this through the build system to verify the fix yet.