### PR TITLE
Create a vertex type for (CNA)CallSet

### DIFF
--- a/bmeg.protograph.yaml
+++ b/bmeg.protograph.yaml
@@ -67,14 +67,16 @@
       merge: true
 
 - label: CallSet
+  vertexes:
+    - label: CallSet
+      gid: "callSet:{{id}}"
+      merge: true
   edges:
-    - fromLabel: Variant
-      label: variantFor
+    - label: callSetOf
       toLabel: Biosample
-      to: "{{biosampleId}}"
-      lookup: "callSet:{{name}}"
-      data:
-        callset: "{{name}}"
+      to: "biosample:{{biosampleId}}"
+      fromLabel: CallSet
+      from: "callSet:{{id}}"
 
 - label: Variant
   vertexes:
@@ -90,11 +92,11 @@
         chromosome: "{{referenceName}}"
   edges:
     - index: calls
+      label: variantOf
+      toLabel: CallSet
+      to: "callSet:{{_index.callSetId}}"
       fromLabel: Variant
-      label: variantFor
-      toLabel: Biosample
       from: "variant:{{referenceName}}:{{start}}:{{end}}:{{referenceBases}}:{{alternateBases|join:,}}"
-      lookup: "{{_index.callSetId}}"
       merge: true
       filter:
         - calls
@@ -246,13 +248,17 @@
       merge: true
 
 - label: CNACallSet
+  vertexes:
+    - label: CNACallSet
+      gid: "cnaCallSet:{{id}}"
+      merge: true
   edges:
-    - fromLabel: CNASegment
-      label: segmentOf
+    - label: cnaCallSetOf
       toLabel: Biosample
-      to: "{{bioSampleId}}"
-      lookup: "cnaCallSet:{{bioSampleId}}"
-      
+      to: "biosample:{{biosampleId}}"
+      fromLabel: CNACallSet
+      from: "cnaCallSet:{{id}}"
+
 - label: CNASegment
   vertexes:
     - label: CNASegment
@@ -261,17 +267,17 @@
       filter:
         - genes
   edges:
-    - fromLabel: CNASegment
-      label: segmentOf
-      toLabel: Biosample
-      from: "cnaSegment:{{callSetId}}:{{referenceName}}:{{start}}:{{end}}:{{value}}"
-      lookup: "{{callSetId}}"
     - index: genes
       fromLabel: CNASegment
-      label: segmentIn
+      label: segmentOf
       toLabel: Gene
       from: "cnaSegment:{{callSetId}}:{{referenceName}}:{{start}}:{{end}}:{{value}}"
       to: "{{_index}}"
+    - label: segmentOf
+      fromLabel: CNASegment
+      from: "cnaSegment:{{callSetId}}:{{referenceName}}:{{start}}:{{end}}:{{value}}"
+      toLabel: CNACallSet
+      to: "cnaCallSet:{{callSetId}}"
 
 - label: Evidence
   vertexes:


### PR DESCRIPTION
Creates a CallSet and CNACallSet vertex type.

Not fully tested yet, since I'm unable to easily build a graph using this protograph. Looks right to the best of my knowledge.

Related to #27 