### PR TITLE
now able to name intermediate outputs

### DIFF
--- a/bmeg.commands.yaml
+++ b/bmeg.commands.yaml
@@ -498,6 +498,7 @@
   inputs:
     - PROTOGRAPH
   outputs:
+    - PROTEIN_INTERACTION
     - VERTEXES
     - EDGES
   steps:
@@ -519,14 +520,14 @@
         SIF: PATHWAY_COMMONS_SIF
         GENES: GENES
       outputs:
-        OUT: PROTEIN_INTERACTION_JSON
+        OUT: PROTEIN_INTERACTION
     - key: pathway-commons-protograph
       command: protograph
       vars:
         LABEL: ProteinInteraction
       inputs:
         PROTOGRAPH: PROTOGRAPH
-        INPUT: PROTEIN_INTERACTION_JSON
+        INPUT: PROTEIN_INTERACTION
       outputs:
         VERTEXES: VERTEXES
         EDGES: EDGES
@@ -552,6 +553,7 @@
   inputs:
     - PROTOGRAPH
   outputs:
+    - PFAM_FAMILY
     - VERTEXES
     - EDGES
   steps:
@@ -564,13 +566,13 @@
       inputs:
         IN: ARCHIVE
       outputs:
-        OUT: PFAM_FAMILY_JSON
+        OUT: PFAM_FAMILY
     - key: pfam-protograph
       vars:
         LABEL: PFAMFamily
       inputs:
         PROTOGRAPH: PROTOGRAPH
-        INPUT: PFAM_FAMILY_JSON
+        INPUT: PFAM_FAMILY
       outputs:
         VERTEXES: VERTEXES
         EDGES: EDGES

--- a/bmeg.processes.yaml
+++ b/bmeg.processes.yaml
@@ -405,6 +405,7 @@
   inputs:
     PROTOGRAPH: source/bmeg.protograph.yaml
   outputs:
+    PROTEIN_INTERACTION: biostream/pathwaycommons/pathwaycommons.ProteinInteraction.json
     VERTEXES: protograph/pathwaycommons/pathwaycommons.ProteinInteraction.Vertex.json
     EDGES: protograph/pathwaycommons/pathwaycommons.ProteinInteraction.Edge.json
 
@@ -416,5 +417,6 @@
   inputs:
     PROTOGRAPH: source/bmeg.protograph.yaml
   outputs:
-    VERTEXES: protograph/pfam/PFAMFamily.Vertex.json
-    EDGES: protograph/pfam/PFAMFamily.Edge.json
+    PFAM_FAMILY: biostream/pfam/pfam.PFAMFamily.json
+    VERTEXES: protograph/pfam/pfam.PFAMFamily.Vertex.json
+    EDGES: protograph/pfam/pfam.PFAMFamily.Edge.json


### PR DESCRIPTION
Composite commands now have the ability to name intermediate outputs, so I updated the commands and processes files to provide `biostream` keys for the PFAM and Pathway Commons transforms.