### PR TITLE
fix ccle/gtex expression tranform command

### DIFF
--- a/bmeg.commands.yaml
+++ b/bmeg.commands.yaml
@@ -87,8 +87,12 @@
 - key: ccle-expression-transform
   image: biostream/ccle-transform
   command:
-    - "/command/convert-ccle-expression.py"
+    - "python"
+    - "/command/convert-gct.py"
+    - "ccle"
+    - "rpkm"
     - "/in/expression"
+    - "/out/expression_ccle.json"
   inputs:
     GCT: /in/expression
   outputs:
@@ -207,7 +211,7 @@
   image: biostream/ccle-transform
   command:
     - "python"
-    - "/opt/convert-gct.py"
+    - "/command/convert-gct.py"
     - "gtex"
     - "rpkm"
     - "/in/gtex.gz"


### PR DESCRIPTION
Closes https://github.com/biostream/gtex-transform/issues/4

And updates the ccle-expression-transform command to use convert-gct.py, a more general version of the original convert-ccle-expression.py