### PR TITLE
use gct-transform. fix broken gtex processes

### DIFF
--- a/bmeg.commands.yaml
+++ b/bmeg.commands.yaml
@@ -84,18 +84,6 @@
   outputs:
     SAMPLES: /out/Sample.json
 
-- key: ccle-expression-transform
-  image: biostream/gct-transform
-  command:
-    - "/opt/gct"
-    - "/in/expression"
-    - "ccle"
-    - "RPKM"
-  inputs:
-    GCT: /in/expression
-  outputs:
-    EXPRESSION: /out/out.json
-
 - key: ctdd-transform
   image: biostream/ctdd-transform
   command:
@@ -207,13 +195,15 @@
     INDIVIDUAL: /out/gtex.bmeg.Individual.json
     BIOSAMPLE: /out/gtex.bmeg.Biosample.json
 
-- key: gtex-expression-transform
+- key: gct-transform
   image: biostream/gct-transform
   command:
     - "/opt/gct"
     - "/in/expression"
-    - "gtex"
+    - "{{SOURCE}}"
     - "RPKM"
+  vars:
+    SOURCE: src
   inputs:
     GTEX: /in/expression
   outputs:

--- a/bmeg.commands.yaml
+++ b/bmeg.commands.yaml
@@ -85,18 +85,16 @@
     SAMPLES: /out/Sample.json
 
 - key: ccle-expression-transform
-  image: biostream/ccle-transform
+  image: biostream/gct-transform
   command:
-    - "python"
-    - "/command/convert-gct.py"
-    - "ccle"
-    - "rpkm"
+    - "/opt/gct"
     - "/in/expression"
-    - "/out/expression_ccle.json"
+    - "ccle"
+    - "RPKM"
   inputs:
     GCT: /in/expression
   outputs:
-    EXPRESSION: /out/expression_ccle.json
+    EXPRESSION: /out/out.json
 
 - key: ctdd-transform
   image: biostream/ctdd-transform
@@ -201,30 +199,25 @@
     - "/opt/gtex_convert.py"
     - "--bio"
     - "/in/biobank.txt"
-    - "--expression"
-    - "/in/gtex.gz"
     - "--out"
     - "/out/gtex."
   inputs:
-    GTEX: /in/gtex.gz
     BIOBANK: /in/biobank.txt
   outputs:
     INDIVIDUAL: /out/gtex.bmeg.Individual.json
     BIOSAMPLE: /out/gtex.bmeg.Biosample.json
 
 - key: gtex-expression-transform
-  image: biostream/ccle-transform
+  image: biostream/gct-transform
   command:
-    - "python"
-    - "/command/convert-gct.py"
+    - "/opt/gct"
+    - "/in/expression"
     - "gtex"
-    - "rpkm"
-    - "/in/gtex.gz"
-    - "/out/gtex.json"
+    - "RPKM"
   inputs:
-    GTEX: /in/gtex.gz
+    GTEX: /in/expression
   outputs:
-    OUT: /out/gtex.json
+    OUT: /out/out.json
 
 - key: go-transform
   image: biostream/go-transform

--- a/bmeg.processes.yaml
+++ b/bmeg.processes.yaml
@@ -154,25 +154,10 @@
 ##############
 ### GTEX
 
-- key: gtex-biobank-extract
-  command: curl-extract
-  vars:
-    URL: http://www.gtexportal.org/static/datasets/biobank/downloads/biobank_collection_20170329_093753.txt
-  outputs:
-    OUT: source/gtex/biobank.txt
-
-- key: gtex-expression-extract
-  command: curl-extract
-  vars:
-    URL: http://www.gtexportal.org/static/datasets/gtex_analysis_v6p/rna_seq_data/GTEx_Analysis_v6p_RNA-seq_RNA-SeQCv1.1.8_gene_rpkm.gct.gz
-  outputs:
-    OUT: source/gtex/gtex-rpkm.gz
- 
 - key: gtex-sample-transform
   command: gtex-sample-transform
   inputs:
-    GTEX: source/gtex/gtex-rpkm.gz
-    BIOBANK: source/gtex/biobank.txt
+    BIOBANK: biobank_collection_20180116_031101.txt
   outputs:
     INDIVIDUAL: biostream/gtex/gtex.Individual.json
     BIOSAMPLE: biostream/gtex/gtex.Biosample.json

--- a/bmeg.processes.yaml
+++ b/bmeg.processes.yaml
@@ -36,7 +36,9 @@
     SAMPLES: biostream/ccle/ccle.Biosample.json
 
 - key: ccle-expression-transform
-  command: ccle-expression-transform
+  command: gct-transform
+  vars:
+    SOURCE: ccle
   inputs:
     GCT: source/CCLE_RNAseq_081117.rpkm.gct
   outputs:
@@ -157,13 +159,15 @@
 - key: gtex-sample-transform
   command: gtex-sample-transform
   inputs:
-    BIOBANK: biobank_collection_20180116_031101.txt
+    BIOBANK: source/gtex/biobank_collection_20180116_031101.txt
   outputs:
     INDIVIDUAL: biostream/gtex/gtex.Individual.json
     BIOSAMPLE: biostream/gtex/gtex.Biosample.json
 
 - key: gtex-expression-transform
-  command: gtex-expression-transform
+  command: gct-transform
+  vars:
+    SOURCE: gtex
   inputs:
     GTEX: source/gtex/GTEx_Analysis_v6p_RNA-seq_RNA-SeQCv1.1.8_gene_rpkm.gct.gz
   outputs:


### PR DESCRIPTION
This updates gct expression transforms to use https://github.com/biostream/gct-transform

I also noticed some broken GTEX extractions. curl doesn't work for those, I had previously uploaded the data manually.

Also, this is a good example of why having a single repo would be better: this relatively simple change required commits, access, builds, PRs, etc. in 4 different repos.